### PR TITLE
Add mkdocstrings python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytest-cov>=3.0.0
 python-statemachine
 mkdocs-material
 mkdocs-jupyter
-mkdocstrings
+mkdocstrings[python]>=0.18
 mkdocs-gen-files
 mkdocs-literate-nav
 mkdocs-section-index


### PR DESCRIPTION
Fixes failing build https://github.com/KIT-MRT/behavior_generation_lecture_python/actions/runs/2406652583