### PR TITLE
Add temporary docs for PRs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,27 @@
+name: Continuous Deployment
+
+on: 
+  push: 
+    branches: [ main ]
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    concurrency: deploy-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.10"
+
+      - name: Set up env
+        run: uv sync --all-extras --frozen
+
+      - name: Copy notebooks to docs folder
+        run: cp -r notebooks/* docs/notebooks
+
+      - run: |
+          uv run ipython kernel install --user --name=behavior_generation_lecture
+          uv run mkdocs gh-deploy --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: Continuous Integration
+
 on: 
   push: 
     branches: [ main ]
@@ -6,12 +7,12 @@ on:
   schedule:
     - cron:  "0 3 * * 1" # Run every Monday 3 am
 
-permissions:
-  pull-requests: write
-
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration and Deployment
+name: Continuous Integration
 on: 
   push: 
     branches: [ main ]
@@ -7,7 +7,7 @@ on:
     - cron:  "0 3 * * 1" # Run every Monday 3 am
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt install python3-tk -y
 
       - name: Set up env
-        run: uv sync --all-extras
+        run: uv sync --all-extras --frozen
 
       - name: Run ruff format
         run: uv run ruff format
@@ -47,32 +47,25 @@ jobs:
       - name: Copy notebooks to docs folder
         run: cp -r notebooks/* docs/notebooks
 
-      - name: Build docs
+      - name: Build PR docs (including running the notebooks)
         run: |
           uv run ipython kernel install --user --name=behavior_generation_lecture
-          uv run mkdocs build
+          uv run mkdocs build --site-dir site/pr-${{ github.event.pull_request.number }}
 
-  deploy-pages:
-    runs-on: ubuntu-latest
-    needs: [test]
-    if: github.ref == 'refs/heads/main'
-    concurrency: deploy-${{ github.ref }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
+      - name: Deploy PR docs
+        if: github.event_name == 'pull_request'
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          version: "0.5.10"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site/pr-${{ github.event.pull_request.number }}
+          destination_dir: pr-${{ github.event.pull_request.number }} # Deploy to subdirectory
+          publish_branch: gh-pages
+          keep_files: true # Retain other content on gh-pages
 
-      - name: Set up env
-        run: uv sync --all-extras
+      - name: Add PR comment with preview link
+        if: github.event_name == 'pull_request'
+        run: |
+            echo "Deployed [https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/](temporary docs)."
 
-      - name: Copy notebooks to docs folder
-        run: cp -r notebooks/* docs/notebooks
-
-      - run: |
-          uv run ipython kernel install --user --name=behavior_generation_lecture
-          uv run mkdocs gh-deploy --force
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 
 on: 
   push: 
-    branches: [ main,feature/new_ci_cd ]
+    branches: [ main ]
   pull_request:
   schedule:
     - cron:  "0 3 * * 1" # Run every Monday 3 am

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron:  "0 3 * * 1" # Run every Monday 3 am
 
+permissions:
+  pull-requests: write
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -62,10 +65,15 @@ jobs:
           publish_branch: gh-pages
           keep_files: true # Retain other content on gh-pages
 
-      - name: Add PR comment with preview link
+      - name: Add PR note
         if: github.event_name == 'pull_request'
-        run: |
-            echo "Deployed [https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/](temporary docs)."
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            ### :books: Docs
+
+            Created [https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/](temporary docs).
+          
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Build PR docs (including running the notebooks)
         run: |
+          sed -i "s/^site_name:.*$/site_name: 'Behavior Generation Lecture - tmp docs for PR ${{ github.event.pull_request.number }}'/" mkdocs.yml
           uv run ipython kernel install --user --name=behavior_generation_lecture
           uv run mkdocs build --site-dir site/pr-${{ github.event.pull_request.number }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 
 on: 
   push: 
-    branches: [ main ]
+    branches: [ main,feature/new_ci_cd ]
   pull_request:
   schedule:
     - cron:  "0 3 * * 1" # Run every Monday 3 am
@@ -73,7 +73,7 @@ jobs:
           message: |
             ### :books: Docs
 
-            Created [https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/](temporary docs).
+            Created [temporary docs](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/).
           
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Decision Making: 
           - Value Iteration: notebooks/mdp_value_iteration.ipynb
           - Q-Learning: notebooks/mdp_q_learning.ipynb
+          - Policy Gradient: notebooks/mdp_policy_gradient.ipynb
   - API Documentation (partial): reference/
 
 plugins:

--- a/notebooks/a_star_notebook.ipynb
+++ b/notebooks/a_star_notebook.ipynb
@@ -59,9 +59,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "behavior_generation_lecture",
    "language": "python",
-   "name": "python3"
+   "name": "behavior_generation_lecture"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/lateral_control_state_based_notebook.ipynb
+++ b/notebooks/lateral_control_state_based_notebook.ipynb
@@ -83,9 +83,9 @@
    "hash": "ea80bdc8d9eecdfb0ad4850befec70bcf98ec6f56b32ef8090165e65e0e9c093"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "behavior_generation_lecture",
    "language": "python",
-   "name": "python3"
+   "name": "behavior_generation_lecture"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/mdp_policy_gradient.ipynb
+++ b/notebooks/mdp_policy_gradient.ipynb
@@ -62,7 +62,7 @@
     "model_checkpoints = policy_gradient(\n",
     "    mdp=grid_mdp,\n",
     "    policy=policy,\n",
-    "    iterations=10,\n",
+    "    iterations=100,\n",
     "    return_history=True,\n",
     ")"
    ]
@@ -107,7 +107,7 @@
     "    w = ipywidgets.interactive(plot_policy_step_grid_map, iteration=iteration_slider)\n",
     "    display(w)\n",
     "else:\n",
-    "    plot_policy_step_grid_map(10)"
+    "    plot_policy_step_grid_map(100)"
    ]
   },
   {
@@ -161,7 +161,7 @@
     "model_checkpoints = policy_gradient(\n",
     "    mdp=highway_mdp,\n",
     "    policy=policy,\n",
-    "    iterations=20,\n",
+    "    iterations=200,\n",
     "    return_history=True,\n",
     ")"
    ]
@@ -205,15 +205,15 @@
     "    w = ipywidgets.interactive(plot_policy_step_grid_map, iteration=iteration_slider)\n",
     "    display(w)\n",
     "else:\n",
-    "    plot_policy_step_grid_map(20)"
+    "    plot_policy_step_grid_map(200)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "behavior_generation_lecture",
    "language": "python",
-   "name": "python3"
+   "name": "behavior_generation_lecture"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/mdp_policy_gradient.ipynb
+++ b/notebooks/mdp_policy_gradient.ipynb
@@ -62,7 +62,7 @@
     "model_checkpoints = policy_gradient(\n",
     "    mdp=grid_mdp,\n",
     "    policy=policy,\n",
-    "    iterations=100,\n",
+    "    iterations=10,\n",
     "    return_history=True,\n",
     ")"
    ]
@@ -107,7 +107,7 @@
     "    w = ipywidgets.interactive(plot_policy_step_grid_map, iteration=iteration_slider)\n",
     "    display(w)\n",
     "else:\n",
-    "    plot_policy_step_grid_map(100)"
+    "    plot_policy_step_grid_map(10)"
    ]
   },
   {
@@ -161,7 +161,7 @@
     "model_checkpoints = policy_gradient(\n",
     "    mdp=highway_mdp,\n",
     "    policy=policy,\n",
-    "    iterations=200,\n",
+    "    iterations=20,\n",
     "    return_history=True,\n",
     ")"
    ]
@@ -205,7 +205,7 @@
     "    w = ipywidgets.interactive(plot_policy_step_grid_map, iteration=iteration_slider)\n",
     "    display(w)\n",
     "else:\n",
-    "    plot_policy_step_grid_map(200)"
+    "    plot_policy_step_grid_map(20)"
    ]
   }
  ],

--- a/notebooks/mdp_q_learning.ipynb
+++ b/notebooks/mdp_q_learning.ipynb
@@ -191,9 +191,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "behavior_generation_lecture",
    "language": "python",
-   "name": "python3"
+   "name": "behavior_generation_lecture"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/mdp_value_iteration.ipynb
+++ b/notebooks/mdp_value_iteration.ipynb
@@ -191,9 +191,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "behavior_generation_lecture",
    "language": "python",
-   "name": "python3"
+   "name": "behavior_generation_lecture"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This PR adds temporary PR docs, such that you can browse the new version of the docs prior to merging. The link to these temporary docs are commented into the PR, as can be seen below.

Also, I separated CI and CD in two files, added the policy gradient notebook to the docs, and did some cleanup in the notebooks (update the kernel specs).